### PR TITLE
Improve scraper URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ python -m top4crawler.main YEAR CONFERENCE [--output FILE]
 ```
 
 `CONFERENCE` can be one of `sp`, `ccs`, `usenix`, or `ndss`. Data will be printed as JSON or written to the specified output file.
+
+The scraper attempts several known program URLs for each conference. If none of
+them are reachable (e.g. because the program page for the given year has not yet
+been published), an empty list will be returned.

--- a/top4crawler/scrapers.py
+++ b/top4crawler/scrapers.py
@@ -3,6 +3,19 @@ from bs4 import BeautifulSoup
 from dataclasses import dataclass
 from typing import List, Optional
 
+
+def _safe_get(urls: List[str]) -> Optional[str]:
+    """Return the body of the first successfully retrieved URL."""
+    for url in urls:
+        try:
+            resp = requests.get(url)
+            if resp.status_code == 200:
+                return resp.text
+        except requests.RequestException:
+            continue
+    print(f"Could not fetch any page from: {', '.join(urls)}")
+    return None
+
 @dataclass
 class Paper:
     title: str
@@ -12,10 +25,14 @@ class Paper:
 
 def fetch_ieee_sp(year: int) -> List[Paper]:
     """Fetch papers from IEEE S&P for the given year."""
-    url = f"https://www.ieee-security.org/TC/SP{year}/program.html"
-    resp = requests.get(url)
-    resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, "html.parser")
+    candidates = [
+        f"https://www.ieee-security.org/TC/SP{year}/program.html",
+        f"https://sp{year}.ieee-security.org/program.html",
+    ]
+    text = _safe_get(candidates)
+    if text is None:
+        return []
+    soup = BeautifulSoup(text, "html.parser")
     papers = []
     for item in soup.select("div.paper"):
         title = item.select_one("div.title").get_text(strip=True)
@@ -29,10 +46,14 @@ def fetch_ieee_sp(year: int) -> List[Paper]:
 
 def fetch_acm_ccs(year: int) -> List[Paper]:
     """Fetch papers from ACM CCS for the given year."""
-    url = f"https://www.sigsac.org/ccs/CCS{year}/program.html"
-    resp = requests.get(url)
-    resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, "html.parser")
+    candidates = [
+        f"https://www.sigsac.org/ccs/CCS{year}/program.html",
+        f"https://www.sigsac.org/ccs/CCS{year}/program/",
+    ]
+    text = _safe_get(candidates)
+    if text is None:
+        return []
+    soup = BeautifulSoup(text, "html.parser")
     papers = []
     for item in soup.select("div.paper"):
         title = item.select_one("h3").get_text(strip=True)
@@ -46,10 +67,14 @@ def fetch_acm_ccs(year: int) -> List[Paper]:
 
 def fetch_usenix_security(year: int) -> List[Paper]:
     """Fetch papers from USENIX Security for the given year."""
-    url = f"https://www.usenix.org/conference/usenixsecurity{year}/presentation"
-    resp = requests.get(url)
-    resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, "html.parser")
+    candidates = [
+        f"https://www.usenix.org/conference/usenixsecurity{year}/presentation",
+        f"https://www.usenix.org/conference/usenixsecurity{year}/program",
+    ]
+    text = _safe_get(candidates)
+    if text is None:
+        return []
+    soup = BeautifulSoup(text, "html.parser")
     papers = []
     for item in soup.select("div.node--type-paper"):
         title = item.select_one("h3.node-title").get_text(strip=True)
@@ -64,10 +89,14 @@ def fetch_usenix_security(year: int) -> List[Paper]:
 
 def fetch_ndss(year: int) -> List[Paper]:
     """Fetch papers from NDSS for the given year."""
-    url = f"https://www.ndss-symposium.org/ndss{year}-program/"
-    resp = requests.get(url)
-    resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, "html.parser")
+    candidates = [
+        f"https://www.ndss-symposium.org/ndss{year}-program/",
+        f"https://www.ndss-symposium.org/ndss{year}/program/",
+    ]
+    text = _safe_get(candidates)
+    if text is None:
+        return []
+    soup = BeautifulSoup(text, "html.parser")
     papers = []
     for item in soup.select("div.paper"):
         title = item.select_one("div.title").get_text(strip=True)


### PR DESCRIPTION
## Summary
- make scrapers try multiple URLs in case program URLs change
- document that a missing program returns an empty list

## Testing
- `python -m top4crawler.main 2023 sp` *(fails: ModuleNotFoundError: No module named 'requests')*