### PR TITLE
Expand crawler sources for multiple years

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,16 @@ python -m top4crawler.main YEAR CONFERENCE [--output FILE]
 ```
 
 `CONFERENCE` can be one of `sp`, `ccs`, `usenix`, or `ndss`. Data will be printed as JSON or written to the specified output file.
+
+The scraper attempts several known program URLs for each conference. If none of
+them are reachable (e.g. because the program page for the given year has not yet
+been published), an empty list will be returned.
+
+For IEEE S&P you can optionally set the environment variable `IEEE_API_KEY` to
+fetch metadata via the IEEE Xplore API (using predefined publication IDs). When
+the API key is absent or the year is unknown, the scraper falls back to parsing
+the conference website.
+
+ACM CCS metadata is retrieved via Crossref when possible and falls back to
+scraping the program page. USENIX Security and NDSS remain purely
+scraper-based but include several candidate URLs per year.

--- a/top4crawler/scrapers.py
+++ b/top4crawler/scrapers.py
@@ -1,7 +1,21 @@
+import os
 import requests
 from bs4 import BeautifulSoup
 from dataclasses import dataclass
 from typing import List, Optional
+
+
+def _safe_get(urls: List[str]) -> Optional[str]:
+    """Return the body of the first successfully retrieved URL."""
+    for url in urls:
+        try:
+            resp = requests.get(url)
+            if resp.status_code == 200:
+                return resp.text
+        except requests.RequestException:
+            continue
+    print(f"Could not fetch any page from: {', '.join(urls)}")
+    return None
 
 @dataclass
 class Paper:
@@ -12,10 +26,47 @@ class Paper:
 
 def fetch_ieee_sp(year: int) -> List[Paper]:
     """Fetch papers from IEEE S&P for the given year."""
-    url = f"https://www.ieee-security.org/TC/SP{year}/program.html"
-    resp = requests.get(url)
-    resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, "html.parser")
+    pub_ids = {
+        2021: "9519381",
+        2020: "9097518",
+        2019: "8803633",
+        2018: "8355477",
+        2017: "7946416",
+        2022: "9749231",
+        2023: "10191403",
+        2024: "11000000",  # placeholder
+    }
+
+    api_key = os.getenv("IEEE_API_KEY")
+    if api_key and year in pub_ids:
+        url = (
+            f"https://ieeexploreapi.ieee.org/api/v1/search/articles?"
+            f"publication_number={pub_ids[year]}&apikey={api_key}"
+        )
+        try:
+            resp = requests.get(url)
+            if resp.status_code == 200:
+                data = resp.json()
+                papers = []
+                for art in data.get("articles", []):
+                    title = art.get("title", "")
+                    authors = [a.get("full_name", "") for a in art.get("authors", [])]
+                    pdf_url = art.get("pdf_url")
+                    abstract = art.get("abstract")
+                    papers.append(Paper(title, authors, pdf_url, abstract))
+                if papers:
+                    return papers
+        except requests.RequestException:
+            pass
+
+    candidates = [
+        f"https://www.ieee-security.org/TC/SP{year}/program.html",
+        f"https://sp{year}.ieee-security.org/program.html",
+    ]
+    text = _safe_get(candidates)
+    if text is None:
+        return []
+    soup = BeautifulSoup(text, "html.parser")
     papers = []
     for item in soup.select("div.paper"):
         title = item.select_one("div.title").get_text(strip=True)
@@ -29,10 +80,45 @@ def fetch_ieee_sp(year: int) -> List[Paper]:
 
 def fetch_acm_ccs(year: int) -> List[Paper]:
     """Fetch papers from ACM CCS for the given year."""
-    url = f"https://www.sigsac.org/ccs/CCS{year}/program.html"
-    resp = requests.get(url)
-    resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, "html.parser")
+    params = {
+        "filter": f"member:320,from-pub-date:{year}-01-01,until-pub-date:{year}-12-31",
+        "rows": 1000,
+    }
+    headers = {"User-Agent": "Top4Crawler/0.1"}
+    try:
+        resp = requests.get("https://api.crossref.org/v1/works", params=params, headers=headers)
+        if resp.status_code == 200:
+            items = resp.json().get("message", {}).get("items", [])
+            papers = []
+            for it in items:
+                titles = it.get("title", [])
+                if not titles:
+                    continue
+                container = "".join(it.get("container-title", []))
+                if "Communications Security" not in container:
+                    continue
+                title = titles[0]
+                authors = [f"{a.get('given','')} {a.get('family','')}".strip() for a in it.get("author", [])]
+                pdf_url = None
+                for link in it.get("link", []):
+                    if link.get("content-type") == "application/pdf":
+                        pdf_url = link.get("URL")
+                        break
+                abstract = it.get("abstract")
+                papers.append(Paper(title, authors, pdf_url, abstract))
+            if papers:
+                return papers
+    except requests.RequestException:
+        pass
+
+    candidates = [
+        f"https://www.sigsac.org/ccs/CCS{year}/program.html",
+        f"https://www.sigsac.org/ccs/CCS{year}/program/",
+    ]
+    text = _safe_get(candidates)
+    if text is None:
+        return []
+    soup = BeautifulSoup(text, "html.parser")
     papers = []
     for item in soup.select("div.paper"):
         title = item.select_one("h3").get_text(strip=True)
@@ -46,10 +132,15 @@ def fetch_acm_ccs(year: int) -> List[Paper]:
 
 def fetch_usenix_security(year: int) -> List[Paper]:
     """Fetch papers from USENIX Security for the given year."""
-    url = f"https://www.usenix.org/conference/usenixsecurity{year}/presentation"
-    resp = requests.get(url)
-    resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, "html.parser")
+    candidates = [
+        f"https://www.usenix.org/conference/usenixsecurity{year}/technical-sessions",
+        f"https://www.usenix.org/conference/usenixsecurity{year}/presentation",
+        f"https://www.usenix.org/conference/usenixsecurity{year}/program",
+    ]
+    text = _safe_get(candidates)
+    if text is None:
+        return []
+    soup = BeautifulSoup(text, "html.parser")
     papers = []
     for item in soup.select("div.node--type-paper"):
         title = item.select_one("h3.node-title").get_text(strip=True)
@@ -64,10 +155,15 @@ def fetch_usenix_security(year: int) -> List[Paper]:
 
 def fetch_ndss(year: int) -> List[Paper]:
     """Fetch papers from NDSS for the given year."""
-    url = f"https://www.ndss-symposium.org/ndss{year}-program/"
-    resp = requests.get(url)
-    resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, "html.parser")
+    candidates = [
+        f"https://www.ndss-symposium.org/ndss{year}-program/",
+        f"https://www.ndss-symposium.org/ndss{year}/program/",
+        f"https://www.ndss-symposium.org/ndss{year}/accepted-papers/",
+    ]
+    text = _safe_get(candidates)
+    if text is None:
+        return []
+    soup = BeautifulSoup(text, "html.parser")
     papers = []
     for item in soup.select("div.paper"):
         title = item.select_one("div.title").get_text(strip=True)


### PR DESCRIPTION
## Summary
- enable IEEE S&P retrieval via IEEE Xplore API with `IEEE_API_KEY`
- try Crossref for ACM CCS papers before scraping
- add extra USENIX and NDSS URL fallbacks
- document optional API usage in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `python -m top4crawler.main 2023 sp` *(fails: ModuleNotFoundError: No module named 'requests')*